### PR TITLE
Use new-style Code Climate badge in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Opal Rails
 
 [![Build Status](https://secure.travis-ci.org/elia/opal-rails.png)](http://travis-ci.org/elia/opal-rails)
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/elia/opal-rails)
+[![Code Climate](https://codeclimate.com/github/elia/opal-rails.png)](https://codeclimate.com/github/elia/opal-rails)
 
 _Rails (3.2+) bindings for [Opal Ruby](http://opalrb.org) (v0.3.27) engine._
 


### PR DESCRIPTION
Rather than the plain blue Code Climate badge, this PR switches to a badge that resembles the Travis-CI one and shows Code Climate's grade-point average for the repo.
