### PR TITLE
Use correct opal-rspec rake path

### DIFF
--- a/lib/tasks/opal-rails_tasks.rake
+++ b/lib/tasks/opal-rails_tasks.rake
@@ -1,6 +1,6 @@
-require 'opal/spec/rake_task'
+require 'opal/rspec/rake_task'
 
-Opal::Spec::RakeTask.new('opal:spec' => :environment) do |server|
+Opal::RSpec::RakeTask.new('opal:spec' => :environment) do |server|
   require 'tempfile'
 
   asset_paths = Opal.paths + Rails.configuration.assets.paths.to_a


### PR DESCRIPTION
The rake task left in `tasks/opal-rails_tasks.rake` is using the path for `opal-spec`. This pull request updates it to use `opal-rspec`.
