### PR TITLE
small grammar fix to indefinite article

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ post.find('.comments').html = comments_html
 ```
 
 
-### As an Haml filter (optional)
+### As a Haml filter (optional)
 
 Of course you need to require `haml-rails` separately since its presence is not assumed
 


### PR DESCRIPTION
Since "Haml" begins with an aspiration (a puff of air, to avoid phonetic terms, as in "horse"), the indefinite article should be "a" not "an" (just as we say "a horse" rather than "an horse").
