### PR TITLE
Fix slightly misleading instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ puts "G'day world!" # check the console!
 # Dom manipulation
 require 'opal-jquery'
 
-Document.ready?
+Document.ready? do
   Element.find('body > header').html = '<h1>Hi there!</h1>'
 end
 ```


### PR DESCRIPTION
I don't think `require opal-jquery` needs to be `require`d explicitly for the DOM manipulation example. However, `Document.ready?` should be in there.
