### PR TITLE
fix NameError for rails < 4.2.0

### DIFF
--- a/lib/rails/generators/opal/assets/assets_generator.rb
+++ b/lib/rails/generators/opal/assets/assets_generator.rb
@@ -9,10 +9,7 @@ module Opal
 
       def initialize(*args)
     
-        module_name = case ::Rails::Generators.const_defined? 'ModelHelpers'
-          when true then  'ModelHelpers'
-          else 'ResourceHelpers'
-        end
+        module_name = ::Rails::Generators.const_defined?('ModelHelpers') ? 'ModelHelpers' : 'ResourceHelpers'
         ::Rails::Generators.const_get(module_name).skip_warn = true
         super
       end


### PR DESCRIPTION
`::Rails::Generators::ModelHelpers` exists since rails 4.2.0.
In prior versions `::Rails::Generators::ResourceHelpers` handles the
warn message.

this fixes #29
