### PR TITLE
use consistent class and file name for generated js file

### DIFF
--- a/lib/rails/generators/opal/assets/assets_generator.rb
+++ b/lib/rails/generators/opal/assets/assets_generator.rb
@@ -15,7 +15,7 @@ module Opal
       end
 
       def copy_opal
-        template 'javascript.js.rb', File.join('app/assets/javascripts', class_path, "#{file_name}_view.js.rb")
+        template 'javascript.js.rb', File.join('app/assets/javascripts', class_path, "#{controller_name}_view.js.rb")
       end
     end
   end


### PR DESCRIPTION
when using `rails g controller foos` the created asset file's file name is singular while its class name is plural.
This fix makes them consistent ('foos_view.js.rb` > `class FoosView`)