### PR TITLE
Use underscore for generated asset file name

### DIFF
--- a/lib/rails/generators/opal/assets/assets_generator.rb
+++ b/lib/rails/generators/opal/assets/assets_generator.rb
@@ -15,7 +15,7 @@ module Opal
       end
 
       def copy_opal
-        template 'javascript.js.rb', File.join('app/assets/javascripts', class_path, "#{controller_name}_view.js.rb")
+        template 'javascript.js.rb', File.join('app/assets/javascripts', "#{controller_name.underscore}_view.js.rb")
       end
     end
   end


### PR DESCRIPTION
makes `rails g controller Foo::Bars` generate `app/assets/javascripts/foo/bars_view.js.rb` instead of `app/assets/javascripts/foo/Foo::Bars_view.js.rb`