### PR TITLE
Improve spec running (rake, in browser and configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ Of course you need to require `haml-rails` separately since its presence is not 
 
 ### Spec!
 
-Add specs into `app/assets/javascripts/spec`:
+Add specs into `/spec-opal`:
 
 and then a spec folder with you specs!
 
 ```ruby
-# app/assets/javascripts/spec/example_spec.js.rb
+# spec-opal/example_spec.js.rb
 
 describe 'a spec' do
   it 'has successful examples' do
@@ -153,6 +153,23 @@ end
 ```
 
 Then visit `/opal_spec` from your app and **reload at will** or use the command line with `rake opal:spec`.
+
+#### CHANGE from versions pre 0.7.1
+
+Specs used to run out of app/assets/javascripts/spec which was problematic because require_tree . would cause opal/sprockets to compile the specs for non spec running.  This could result in bad specs that prevent your application Opal code from compiling, and even if it compiles you'll get exceptions about the test framework methods not being defined.  To address this, specs have been moved out of the app/assets/javascripts to Rails.root/spec-opal.  The name spec-opal was chosen to put it close to the spec directory.  We don't want to put specs in spec directory because we don't want the "backend" rspec to run those.
+
+The location of specs is configurable. To restore the old location of app/assets/javascripts/spec add an initializer file like the below.
+
+```ruby
+# config/initializers/opal.rb
+Rails.application.config.opal.spec_location = "app/assets/javascripts/spec"
+
+```
+
+Similarly, you can put the opal specs in another location via a similar initializer call.
+
+
+
 
 ![1 examples, 0 failures](http://f.cl.ly/items/001n0V0g0u0v14160W2G/Schermata%2007-2456110%20alle%201.06.29%20am.png)
 

--- a/app/controllers/opal_spec_controller.rb
+++ b/app/controllers/opal_spec_controller.rb
@@ -4,6 +4,15 @@ class OpalSpecController < ActionController::Base
   def run
   end
 
+  def file
+    spec_file = Dir["#{spec_location}/#{params[:path]}*.{rb,opal}"].first
+    Opal.paths.concat Rails.application.config.assets.paths
+    builder = Opal::Builder.new
+    file = File.new spec_file
+    builder.build_str file.read, spec_file
+
+    render js: builder.to_s
+  end
 
   private
 
@@ -25,8 +34,12 @@ class OpalSpecController < ActionController::Base
   end
 
   def spec_files_for_glob glob = '**'
-    Dir[Rails.root.join("{app,lib}/assets/javascripts/spec/#{glob}.{rb,opal}")].map do |path|
-      path.split('assets/javascripts/spec/').flatten.last.gsub(/(\.rb|\.opal)/, '')
+    Dir[Rails.root.join("#{spec_location}/#{glob}.{rb,opal}")].map do |path|
+      path.split("#{spec_location}/").flatten.last.gsub(/(\.rb|\.opal)/, '')
     end.uniq
+  end
+
+  def spec_location
+    Rails.application.config.opal.spec_location
   end
 end

--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -4,4 +4,15 @@ module OpalHelper
     js_code = Opal.compile(opal_code)
     javascript_tag js_code
   end
+
+  def spec_include_tag(*sources)
+    options = sources.extract_options!.stringify_keys
+    path_options = options.extract!('protocol', 'extname').symbolize_keys
+    sources.uniq.map { |source|
+      tag_options = {
+        "src" => "/opal_spec_files/#{source}"
+      }.merge!(options)
+      content_tag(:script, "", tag_options)
+    }.join("\n").html_safe
+  end
 end

--- a/app/views/layouts/opal_spec.html.erb
+++ b/app/views/layouts/opal_spec.html.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Opal Spec Runner</title>
     <%= javascript_include_tag 'opal-rspec-runner' %>
-    <%= javascript_include_tag *spec_files.map { |f| "spec/#{f}"} %>
+    <%= spec_include_tag *spec_files.map { |f| "#{f}"} %>
   <style>
     body { font-family: sans-serif; }
   </style>

--- a/lib/assets/javascripts/sprockets_runner.rb.erb
+++ b/lib/assets/javascripts/sprockets_runner.rb.erb
@@ -1,0 +1,11 @@
+# This file is used by Opal::Server to basically load all spec files that
+# can be found in the spec/ directory.
+
+require 'opal'
+require 'opal-rspec'
+<% spec_location = Rails.application.config.opal.spec_location %>
+<% Dir.glob("#{spec_location}/**/*_spec*.{rb,opal}").each do |s| %>
+require <%= s.sub(/^#{spec_location}\//, '').sub(/\.(rb|opal)$/, '').sub(/\.js/,'').inspect %>
+<% end %>
+
+Opal::RSpec::Runner.autorun

--- a/lib/opal/rails/engine.rb
+++ b/lib/opal/rails/engine.rb
@@ -8,7 +8,8 @@ module Opal
       config.app_generators.javascript_engine :opal
 
       config.opal = ActiveSupport::OrderedOptions.new
-
+      # new default location, override-able in a Rails initializer
+      config.opal.spec_location = "spec-opal"
 
       # Cache eager_load_paths now, otherwise the assets dir is added
       # and its .rb files are eagerly loaded.
@@ -42,6 +43,7 @@ module Opal
           end
 
           get '/opal_spec' => 'opal_spec#run'
+          get '/opal_spec_files/*path' => 'opal_spec#file'
         end
       end
 

--- a/lib/tasks/opal-rails_tasks.rake
+++ b/lib/tasks/opal-rails_tasks.rake
@@ -8,6 +8,7 @@ Opal::RSpec::RakeTask.new('opal:spec' => :environment) do |server|
 
   server.sprockets.clear_paths
   asset_paths << File.dirname(tempfile.path)
+  asset_paths << Rails.application.config.opal.spec_location
   server.main = File.basename(tempfile.path, '.js.rb')
 
   asset_paths.each { |path| server.append_path path }

--- a/test_app/config/initializers/opal.rb
+++ b/test_app/config/initializers/opal.rb
@@ -1,0 +1,2 @@
+# needs to be full pathname instead of relative pathname to run in the opal-rails spec
+Rails.application.config.opal.spec_location = "#{Rails.root}/app/assets/javascripts/spec"


### PR DESCRIPTION
* get rake opal:spec task working
* change default location of specs outside of asset pipeline,
* handle compilation of files outside of asset pipeline
* make location configurable
* update Readme