### PR TITLE
Fix the first steps instructions for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ Now ships with a patch to sprockets cache key to include processor version that 
 You can rename `app/assets/javascripts/application.js` to `application.js.rb`. Even if not necessary, it is recommended to change Sprockets' `//= require` statements to Ruby' `require` methods.
 Sprockets' `//= require` statements won't be known by the opal builder and therefore you can end up adding something twice.
 
-Both of the following examples would work:
+For Opal 0.7 and below, the following example should work:
 
 ```js
 # app/assets/javascripts/application.js.rb
 
-//= require opal
-//= require opal_ujs
-//= require turbolinks
-//= require_tree .
+#= require opal
+#= require opal_ujs
+#= require turbolinks
+#= require_tree .
 ```
+
+For Opal 0.8 and above, you should be able to use the following syntax:
 
 ```ruby
 # app/assets/javascripts/application.js.rb

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sprockets' `//= require` statements won't be known by the opal builder and there
 
 For Opal 0.7 and below, the following example should work:
 
-```js
+```ruby
 # app/assets/javascripts/application.js.rb
 
 #= require opal


### PR DESCRIPTION
If the users follow current instructions they will hit the wall at the moment. The example using Ruby require syntax does not work at all. The example using sprockets commetns syntax will raise ruby syntax errors in editors such as RubyMine or Vim (because // is not valid Ruby comment syntax).

This change fixes both issues:
- clarifies which syntax can be used for which versions of Ruby
- uses # comment syntax instead of // for better support of Ruby syntax aware editors