### PR TITLE
Remove Rails version number from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![fun guaranteed](https://img.shields.io/badge/fun-guaranteed-brightgreen.svg)
 ![web scale](http://img.shields.io/badge/webscale-over%209000-green.svg)
 
-_Rails (3.2+, 4.0) bindings for [Opal Ruby](http://opalrb.org) engine. ([Changelog](https://github.com/opal/opal-rails/blob/master/CHANGELOG.md))_
+_Rails bindings for [Opal Ruby](http://opalrb.org) engine. ([Changelog](https://github.com/opal/opal-rails/blob/master/CHANGELOG.md))_
 
 
 


### PR DESCRIPTION
opal-rails works without any problems in versions higher than 4.0 and I'd guess that not many people will introduce a new scripting language in versions below 3.2 so it's best to just leave the version numbers out.