### PR TITLE
Lock sprockets-rails due to v3.0.0 nil assets:

### DIFF
--- a/opal-rails.gemspec
+++ b/opal-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'rails',               '>= 3.2', '< 5.0'
+  s.add_dependency 'sprockets-rails',     '< 3.0.0'
   s.add_dependency 'opal',                '> 0.8.0', '< 0.10.0'
   s.add_dependency 'opal-jquery',         '~> 0.4.0'
   s.add_dependency 'opal-rspec',          '~> 0.5.0.beta3'


### PR DESCRIPTION
NoMethodError: undefined method `append_path' for nil:NilClass
/home/travis/.rvm/gems/ruby-2.1.5/gems/opal-rails-0.8.0/lib/opal/rails/engine.rb:34:in `block in <class:Engine>'