### PR TITLE
Update assets_generator.rb

### DIFF
--- a/lib/rails/generators/opal/assets/assets_generator.rb
+++ b/lib/rails/generators/opal/assets/assets_generator.rb
@@ -1,21 +1,11 @@
 require 'rails/generators/named_base'
-require 'rails/generators/resource_helpers'
 
 module Opal
   module Generators
     class AssetsGenerator < ::Rails::Generators::NamedBase
-      include ::Rails::Generators::ResourceHelpers
       source_root __dir__+'/templates'
-
-      def initialize(*args)
-    
-        module_name = ::Rails::Generators.const_defined?('ModelHelpers') ? 'ModelHelpers' : 'ResourceHelpers'
-        ::Rails::Generators.const_get(module_name).skip_warn = true
-        super
-      end
-
       def copy_opal
-        template 'javascript.js.rb', File.join('app/assets/javascripts', "#{controller_name.underscore}_view.js.rb")
+        template 'javascript.js.rb', File.join('app/assets/javascripts', class_path, "#{file_name}.js.rb")
       end
     end
   end


### PR DESCRIPTION
depend on https://github.com/opal/opal-rails/issues/85

could not understand for what this?
```rb
def initialize(*args)
  module_name = ::Rails::Generators.const_defined?('ModelHelpers') ? 'ModelHelpers' : 'ResourceHelpers'
  ::Rails::Generators.const_get(module_name).skip_warn = true
  super
end
```

everything worked better without it