### PR TITLE
Default skip_onload to true when in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Whitespace conventions:
 
 
 
+## [1.1.2](https://github.com/opal/opal-rails/compare/v1.1.1...v1.1.2) - 2019-09-26
+
+
+### Fixed
+
+- Default `skip_onload` to `true` when `javascript_asset_tag` is in debug mode, otherwise some assets may be loaded in the browser after the main source, thus being never loading by the Opal runtime.
+
+
+
+
 ## [1.1.1](https://github.com/opal/opal-rails/compare/v1.1.0...v1.1.1) - 2019-09-14
 
 

--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -10,20 +10,21 @@ module OpalHelper
   end
 
   def javascript_include_tag(*sources)
-    options = sources.extract_options!
+    options = sources.extract_options!.symbolize_keys
+    debug = options[:debug] != false
     skip_loader = options.delete(:skip_opal_loader)
-    skip_onload = options.delete(:force_opal_loader_tag)
+    force_opal_loader_tag = options.delete(:force_opal_loader_tag) || debug
 
-    return super(*sources, options) if skip_loader
+    return super(*sources, options) if skip_loader && !force_opal_loader_tag
 
     script_tags = "".html_safe
     sources.each do |source|
       load_asset_code = Opal::Sprockets.load_asset(source)
       loading_code = "if(window.Opal && Opal.modules[#{source.to_json}]){#{load_asset_code}}"
 
-      if skip_onload
+      if force_opal_loader_tag
         script_tags << super(source, options)
-        script_tags << javascript_tag(loading_code)
+        script_tags << "\n".html_safe + javascript_tag(loading_code)
       else
         script_tags << super(source, options.merge(onload: loading_code))
       end

--- a/lib/opal/rails/version.rb
+++ b/lib/opal/rails/version.rb
@@ -1,5 +1,5 @@
 module Opal
   module Rails
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end


### PR DESCRIPTION
Otherwise some assets may be loaded in the browser after the main
source, thus being never loading by the Opal runtime.

Fixes #112 