### PR TITLE
opal_tag should mirror the javascript_tag api

### DIFF
--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -1,12 +1,18 @@
 require 'opal/sprockets'
 
 module OpalHelper
-  def opal_tag(opal_code = nil, &block)
-    opal_code ||= capture(&block)
+  def opal_tag(opal_code = nil, html_options = {}, &block)
+    if block_given?
+      html_options = opal_code if opal_code.is_a?(Hash)
+      opal_code = capture(&block)
+    end
+
     compiler_options = Opal::Config.compiler_options.merge(requirable: false)
     compiler = Opal::Compiler.new(opal_code, compiler_options)
     js_code = compiler.compile
-    javascript_tag js_code
+    javascript_tag html_options do
+      js_code
+    end
   end
 
   def javascript_include_tag(*sources)

--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -1,14 +1,14 @@
 require 'opal/sprockets'
 
 module OpalHelper
-  def opal_tag(opal_code = nil, html_options = {}, &block)
+  def opal_tag(opal_code_or_options = nil, html_options = {}, &block)
     if block_given?
-      html_options = opal_code if opal_code.is_a?(Hash)
-      opal_code = capture(&block)
+      html_options = opal_code_or_options if opal_code_or_options.is_a?(Hash)
+      opal_code_or_options = capture(&block)
     end
 
     compiler_options = Opal::Config.compiler_options.merge(requirable: false)
-    compiler = Opal::Compiler.new(opal_code, compiler_options)
+    compiler = Opal::Compiler.new(opal_code_or_options, compiler_options)
     js_code = compiler.compile
     javascript_tag html_options do
       js_code

--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -17,7 +17,7 @@ module OpalHelper
 
   def javascript_include_tag(*sources)
     options = sources.extract_options!.symbolize_keys
-    debug = options[:debug] != false
+    debug = options.delete(:debug) != false
     skip_loader = options.delete(:skip_opal_loader)
     force_opal_loader_tag = options.delete(:force_opal_loader_tag) || debug
 
@@ -30,7 +30,7 @@ module OpalHelper
 
       if force_opal_loader_tag
         script_tags << super(source, options)
-        script_tags << "\n".html_safe + javascript_tag(loading_code)
+        script_tags << "\n".html_safe + javascript_tag(loading_code, options)
       else
         script_tags << super(source, options.merge(onload: loading_code))
       end

--- a/app/helpers/opal_helper.rb
+++ b/app/helpers/opal_helper.rb
@@ -11,7 +11,7 @@ module OpalHelper
     compiler = Opal::Compiler.new(opal_code_or_options, compiler_options)
     js_code = compiler.compile
     javascript_tag html_options do
-      js_code
+      js_code.html_safe
     end
   end
 

--- a/spec/helpers/opal_helper_spec.rb
+++ b/spec/helpers/opal_helper_spec.rb
@@ -55,8 +55,13 @@ describe OpalHelper, :js, type: :view do
       %(<script>), %(//<![CDATA[), loading_code, %(//]]>), %(</script>),
     ].join("\n")
 
+    loading_code_with_options_in_script_tag = [
+      %(<script defer="defer">), %(//<![CDATA[), loading_code, %(//]]>), %(</script>),
+    ].join("\n")
+
     expect(helper.javascript_include_tag('application', debug: true)).to include(loading_code_in_script_tag)
     expect(helper.javascript_include_tag('application', debug: true)).not_to include(escaped_loading_code)
+    expect(helper.javascript_include_tag('application', debug: true, defer: true)).not_to include(escaped_loading_code)
 
     expect(helper.javascript_include_tag('application', debug: false)).to include(escaped_loading_code)
     expect(helper.javascript_include_tag('application', debug: false)).not_to include(loading_code_in_script_tag)

--- a/spec/helpers/opal_helper_spec.rb
+++ b/spec/helpers/opal_helper_spec.rb
@@ -6,15 +6,38 @@ describe OpalHelper, :js, type: :view do
   let(:helper) { view }
 
   describe '#opal_tag' do
-    it 'compiles to js' do
-      allow(helper).to receive(:javascript_tag) { |code| code }
-      ruby_code = 'puts 5'
-
-      expect(Opal::Compiler).to receive(:new)
+    let(:ruby_code) { 'puts 5' }
+    let(:compiled_ruby_code) { 'self.$puts(5)' }
+    let(:html_options) { { async: true } }
+    before do
+      allow(helper).to receive(:javascript_tag).and_call_original
+      allow(Opal::Compiler).to receive(:new)
         .with(ruby_code, hash_including(requirable: false))
         .and_call_original
+    end
 
-      expect(helper.opal_tag(ruby_code)).to include('self.$puts(5)')
+    context 'when the ruby code is passed inline' do
+      it 'compiles the ruby code to js' do
+        expect(helper.opal_tag(ruby_code)).to include(compiled_ruby_code)
+      end
+
+      it 'passes the html_options to the javascript_tag' do
+        helper.opal_tag(ruby_code, html_options)
+        expect(helper).to have_received(:javascript_tag).with(html_options)
+      end
+    end
+
+    context 'when the ruby code is passed as a block' do
+      it 'compiles the block to js' do
+        expect(helper.opal_tag { ruby_code }).to include(compiled_ruby_code)
+      end
+
+      it 'uses the options as the first argument' do
+        aggregate_failures do
+          expect(helper.opal_tag(html_options) { ruby_code }).to include(compiled_ruby_code)
+          expect(helper).to have_received(:javascript_tag).with(html_options)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently it's not possible to pass `html_options` to the `javascript_tag`. 
So the following is not possible
```
opal_tag nonce: true do
  # some javascript
end
```
This PR fixes that and provides an identical api to javascript_tag so it behaves as you would think it would