### PR TITLE
Fix error in opal:watch task regarding target thread

### DIFF
--- a/lib/opal/rails/watch_runner.rb
+++ b/lib/opal/rails/watch_runner.rb
@@ -95,12 +95,14 @@ module Opal
         @opal_dependencies = normalize_paths(Opal.dependent_files)
         rebuild_reverse_dependencies!
 
-        watcher&.stop
+        old_watcher = watcher
         self.watcher = file_watcher_class.new(files: watched_files,
                                               extra_directories: extra_directories) do |modified:, added:, removed:|
           process_changes(modified: modified, added: added, removed: removed)
         end
         watcher.start
+
+        Thread.new { old_watcher.stop } if old_watcher
       end
 
       def rebuild_reverse_dependencies!


### PR DESCRIPTION
When running the task `bin/rails opal:watch` I get the error _Opal build error: Target thread must not be current thread_.

Step to reproduce:

1. Run `bin/rails opal:watch`
2. Edit a opal file
3. Edit for a second a file

--> The error appears

After investigating, the error appear to be that calling `watcher&.stop` try to kill the current Thread.

The fix was to save the current thread, create the new watcher and then stop the old thread in a separate thread